### PR TITLE
Add 3-part blog series on Copilot Context Engineering

### DIFF
--- a/src/data/blog/engenharia-de-contexto-no-copilot-parte-1.md
+++ b/src/data/blog/engenharia-de-contexto-no-copilot-parte-1.md
@@ -1,0 +1,76 @@
+---
+author: Vinicius Costa
+pubDatetime: 2026-03-24T01:25:05Z
+title: "Engenharia de Contexto no Copilot - Parte 1: Fundamentos e Curadoria"
+slug: engenharia-de-contexto-no-copilot-parte-1
+featured: false
+draft: false
+tags:
+  - inteligencia-artificial
+  - copilot
+  - context-engineering
+  - vscode
+description: "Uma introdução à engenharia de contexto no VS Code Copilot e como estruturar o contexto inicial do projeto usando arquivos de documentação e instruções customizadas."
+---
+
+A engenharia de contexto é uma das habilidades mais críticas para desenvolvedores que utilizam ferramentas de IA como o GitHub Copilot no VS Code. Não se trata apenas de escrever um bom prompt isolado, mas de estabelecer uma base sólida de conhecimento que permita à IA entender não apenas *como* codificar, mas *o que* e *por que* ela está construindo algo dentro do ecossistema do seu projeto.
+
+Nesta primeira parte de nossa série sobre Engenharia de Contexto, vamos explorar os fundamentos desta abordagem e como configurar a curadoria inicial do seu projeto.
+
+## O que é Engenharia de Contexto?
+
+A engenharia de contexto é uma abordagem sistemática para fornecer aos agentes de IA informações contextuais ricas e direcionadas. Ao curar informações essenciais do projeto — como visão do produto, princípios de arquitetura e diretrizes de contribuição — você permite que a IA tome decisões mais alinhadas com os objetivos do negócio e as convenções técnicas da sua equipe.
+
+### Por que isso ajuda?
+
+Embora os modelos de linguagem modernos consigam "ler" o seu código, informações cruciais muitas vezes estão enterradas em comentários, espalhadas por múltiplos arquivos ou sequer documentadas no código fonte. Ao fornecer um resumo conciso e estruturado, você garante que o agente tenha acesso imediato aos critérios críticos de tomada de decisão, reduzindo alucinações e respostas genéricas.
+
+## O Fluxo de Trabalho de Engenharia de Contexto
+
+O fluxo de trabalho recomendado no VS Code consiste em três etapas principais:
+
+1.  **Curadoria do contexto global do projeto**: Usar instruções customizadas e arquivos de documentação para alinhar a IA.
+2.  **Geração do plano de implementação**: Criar uma persona de planejamento para desenhar a solução antes de codar.
+3.  **Geração do código de implementação**: Produzir código baseado no plano, seguindo diretrizes de estilo e testes.
+
+---
+
+## Passo 1: Curadoria do Contexto Global
+
+Para fundamentar o agente de IA nas especificidades do seu projeto, o primeiro passo é coletar e estruturar a documentação chave.
+
+### 1. Documentação em Markdown
+
+Crie ou atualize arquivos Markdown na raiz do seu repositório para descrever os pilares do projeto. Se você não tem esses arquivos, pode até pedir para o Copilot gerá-los baseando-se no código existente:
+
+*   **`PRODUCT.md`**: Descreve a visão do produto, objetivos de negócio e funcionalidades principais.
+*   **`ARCHITECTURE.md`**: Detalha a arquitetura do sistema, padrões de design e princípios técnicos.
+*   **`CONTRIBUTING.md`**: Define as diretrizes para desenvolvedores, convenções de código e melhores práticas.
+
+### 2. Instruções Customizadas do Copilot
+
+O VS Code permite criar um arquivo `.github/copilot-instructions.md` na raiz do repositório. As instruções contidas neste arquivo são incluídas automaticamente em todas as interações de chat como contexto fundamental.
+
+Um exemplo básico de estrutura para este arquivo:
+
+```markdown
+# Diretrizes do Projeto [Nome do Projeto]
+
+* [Visão e Objetivos do Produto](../PRODUCT.md): Compreenda a visão de alto nível para garantir alinhamento.
+* [Arquitetura e Princípios de Design](../ARCHITECTURE.md): Padrões de arquitetura que guiam o desenvolvimento.
+* [Diretrizes de Contribuição](../CONTRIBUTING.md): Visão geral das práticas de colaboração e padrões de código.
+
+Sugira atualizações nestes documentos se encontrar informações incompletas ou conflitantes durante o trabalho.
+```
+
+### Dica de Ouro: Comece Pequeno
+
+Não tente documentar cada detalhe técnico imediatamente. Comece com um contexto conciso e foque nas informações mais críticas. À medida que você observa onde a IA comete erros repetitivos (como usar comandos de shell errados ou ignorar certos padrões de design), adicione regras específicas para corrigir esses comportamentos.
+
+Na próxima parte desta série, veremos como usar esse contexto para criar planos de implementação detalhados e agentes customizados de planejamento.
+
+---
+
+## 📎 Fonte Original
+
+> Este post foi baseado no artigo original: [Set up a context engineering flow in VS Code](https://code.visualstudio.com/docs/copilot/guides/context-engineering-guide)

--- a/src/data/blog/engenharia-de-contexto-no-copilot-parte-2.md
+++ b/src/data/blog/engenharia-de-contexto-no-copilot-parte-2.md
@@ -1,0 +1,98 @@
+---
+author: Vinicius Costa
+pubDatetime: 2026-03-24T01:25:05Z
+title: "Engenharia de Contexto no Copilot - Parte 2: Planejamento e Implementação"
+slug: engenharia-de-contexto-no-copilot-parte-2
+featured: false
+draft: false
+tags:
+  - inteligencia-artificial
+  - copilot
+  - agents
+  - vscode
+  - tdd
+description: "Aprenda a criar planos de implementação estruturados e usar agentes customizados no Copilot para automatizar o ciclo de planejamento e geração de código."
+---
+
+Depois de estabelecermos a base de conhecimento do projeto na [Parte 1](./engenharia-de-contexto-no-copilot-parte-1), o próximo passo na engenharia de contexto é transformar esse conhecimento em ação. Nesta segunda parte, vamos focar em como o Copilot pode ajudar a planejar funcionalidades complexas e executar a implementação de forma estruturada.
+
+## Passo 2: Criar o Plano de Implementação
+
+Muitas vezes, o maior erro ao usar IA é pular direto para o código. Funcionalidades complexas exigem um plano. O uso de IA para gerar esse plano garante que você considerou todos os requisitos antes de escrever a primeira linha de código.
+
+### 1. Template de Plano de Implementação
+
+O uso de um template garante que a IA colete todas as informações necessárias de forma consistente. Crie um arquivo `plan-template.md` para guiar o agente:
+
+```markdown
+---
+title: [Título descritivo da funcionalidade]
+date_created: [YYYY-MM-DD]
+---
+# Plano de Implementação: <funcionalidade>
+[Breve descrição dos requisitos e objetivos]
+
+## Arquitetura e Design
+Considerações de design e mudanças estruturais.
+
+## Tarefas
+- [ ] Tarefa 1
+- [ ] Tarefa 2
+
+## Perguntas Abertas
+Incertezas que precisam de esclarecimento.
+```
+
+### 2. Agentes Customizados de Planejamento
+
+Você pode criar um agente dedicado ao planejamento definindo uma persona específica no arquivo `.github/agents/plan.agent.md`. Este agente deve focar em arquitetura e não em escrever código diretamente.
+
+Exemplo de configuração de um agente de planejamento:
+
+```yaml
+---
+description: 'Arquiteto e planejador para criar planos detalhados.'
+tools: ['web/fetch', 'search/codebase', 'agent']
+handoffs:
+- label: Iniciar Implementação
+    agent: tdd
+    prompt: Agora implemente o plano acima usando princípios de TDD.
+    send: true
+---
+# Agente de Planejamento
+Você é um arquiteto focado em decompor requisitos complexos em tarefas acionáveis.
+```
+
+### 3. Arquivos de Prompt (Prompt Files)
+
+Opcionalmente, use arquivos de prompt como `.github/prompts/plan-qna.prompt.md` para criar fluxos de trabalho que forçam a IA a fazer perguntas de esclarecimento antes de começar o planejamento, reduzindo mal-entendidos.
+
+---
+
+## Passo 3: Gerar o Código de Implementação
+
+Com o plano refinado e aprovado, entramos na fase de execução.
+
+### Agentes de Implementação Especializados
+
+Em vez de usar um chat genérico, você pode usar um agente especializado em implementação, como um focado em **TDD (Test-Driven Development)**. Configure um arquivo `.github/agents/tdd.agent.md` com diretrizes claras:
+
+1.  **Escreva os testes primeiro**: Codifique os critérios de aceitação.
+2.  **Implementação mínima**: Escreva apenas o código necessário para passar nos testes.
+3.  **Refatore**: Melhore o código mantendo os testes verdes.
+
+### O Poder do Agente Autônomo
+
+O modo "Agent" no Copilot é otimizado para executar tarefas multi-etapas. Você só precisa fornecer o arquivo de plano (ex: `implemente #meu-plano.md`) e ele será capaz de navegar pelo projeto, entender as dependências e realizar as alterações necessárias de forma autônoma.
+
+### Dica: Revisão por um "Novo Par de Olhos"
+
+Após a implementação, abra um novo chat e peça para o agente revisar o código gerado em relação ao plano original. Isso ajuda a identificar requisitos negligenciados ou inconsistências técnicas.
+
+Na última parte desta série, abordaremos as melhores práticas para manter este ecossistema saudável e como escalar a engenharia de contexto para grandes equipes.
+
+---
+
+## 📎 Fonte Original
+
+> Este post foi baseado no artigo original: [Set up a context engineering flow in VS Code](https://code.visualstudio.com/docs/copilot/guides/context-engineering-guide)

--- a/src/data/blog/engenharia-de-contexto-no-copilot-parte-3.md
+++ b/src/data/blog/engenharia-de-contexto-no-copilot-parte-3.md
@@ -1,0 +1,74 @@
+---
+author: Vinicius Costa
+pubDatetime: 2026-03-24T01:25:05Z
+title: "Engenharia de Contexto no Copilot - Parte 3: Boas Práticas e Escala"
+slug: engenharia-de-contexto-no-copilot-parte-3
+featured: false
+draft: false
+tags:
+  - inteligencia-artificial
+  - copilot
+  - best-practices
+  - scalability
+  - vscode
+description: "Explore as melhores práticas de gerenciamento de contexto, evite antipadrões e aprenda como escalar a engenharia de contexto para grandes equipes e projetos."
+---
+
+Concluímos nossa jornada pela engenharia de contexto no Copilot explorando como manter esse sistema sustentável e eficaz a longo prazo. Depois de estruturar o conhecimento ([Parte 1](./engenharia-de-contexto-no-copilot-parte-1)) e orquestrar o planejamento e a implementação ([Parte 2](./engenharia-de-contexto-no-copilot-parte-2)), precisamos garantir que esse fluxo de trabalho escale com o seu projeto.
+
+## Melhores Práticas e Padrões Comuns
+
+Adotar a engenharia de contexto requer disciplina. Aqui estão as diretrizes fundamentais:
+
+### 1. Princípios de Gerenciamento de Contexto
+
+*   **Comece pequeno e itere**: Não sobrecarregue a IA com informações irrelevantes no início. Adicione detalhes progressivamente conforme necessário.
+*   **Mantenha o contexto atualizado**: Documentação obsoleta é pior do que nenhuma documentação. Use o próprio Copilot para auditar e atualizar seus arquivos de referência conforme o código evolui.
+*   **Isolamento de contexto**: Mantenha diferentes tipos de trabalho (planejamento, codificação, depuração) em sessões de chat separadas para evitar confusão entre contextos.
+
+### 2. Estratégias de Documentação
+
+*   **Documentos vivos**: Trate suas instruções customizadas e agentes como recursos em constante evolução. Refine-os com base nos erros que você observa a IA cometer.
+*   **Foco na decisão**: Priorize informações que ajudem a IA a tomar decisões arquiteturais, em vez de fornecer detalhes técnicos exaustivos que já podem ser inferidos do código.
+*   **Padrões consistentes**: Documente suas convenções de nomenclatura e padrões de design para garantir que a IA gere código coerente com o restante do projeto.
+
+### 3. Otimização do Fluxo de Trabalho
+
+*   **Transições entre agentes**: Use *handoffs* para guiar o trabalho de forma fluida entre o agente de planejamento e o agente de implementação.
+*   **Ciclos de feedback**: Valide continuamente se a IA está entendendo o contexto. Faça perguntas de esclarecimento e corrija o curso cedo.
+
+---
+
+## Antipadrões a Evitar
+
+Cuidado para não cair nestas armadilhas comuns:
+
+*   **Context dumping**: Fornecer excesso de informações genéricas ou desfocadas que diluem o foco da IA.
+*   **Orientações inconsistentes**: Certifique-se de que sua documentação de apoio não contradiga as regras estabelecidas nas instruções customizadas.
+*   **Negligenciar a validação**: Nunca presuma que a IA entendeu o contexto perfeitamente. Teste o entendimento antes de proceder com mudanças complexas.
+
+---
+
+## Escalando para Times e Grandes Projetos
+
+À medida que o uso de IA se expande na organização, a engenharia de contexto deve acompanhar:
+
+*   **Para equipes**: Compartilhe suas configurações de agentes e instruções via controle de versão (Git). Estabeleça convenções de time para manter esse contexto compartilhado.
+*   **Para grandes projetos**: Considere criar **hierarquias de contexto**. Você pode ter instruções globais para o repositório todo e arquivos de instruções específicos em subdiretórios para módulos ou serviços individuais.
+*   **Para múltiplos projetos**: Crie templates reutilizáveis de agentes e prompts que possam ser adotados rapidamente por novos projetos da empresa.
+
+## Medindo o Sucesso
+
+Uma estratégia bem-sucedida de engenharia de contexto resultará em:
+
+1.  **Menos "vai e vem"**: Redução da necessidade de corrigir ou redirecionar as respostas da IA.
+2.  **Qualidade de código consistente**: O código gerado segue os padrões da equipe sem intervenção manual constante.
+3.  **Implementação mais rápida**: Menos tempo explicando o básico e mais tempo focando na lógica de negócio.
+
+A engenharia de contexto não é uma tarefa única, mas um investimento contínuo na eficiência do seu desenvolvimento assistido por IA. Ao tratar as instruções e o contexto como parte integrante da sua base de código, você eleva o Copilot de um assistente de autocompletar para um parceiro de engenharia verdadeiramente inteligente.
+
+---
+
+## 📎 Fonte Original
+
+> Este post foi baseado no artigo original: [Set up a context engineering flow in VS Code](https://code.visualstudio.com/docs/copilot/guides/context-engineering-guide)


### PR DESCRIPTION
I have created a three-part blog post series in Brazilian Portuguese about Context Engineering in VS Code Copilot. 

- Part 1 covers the basics and how to set up project-wide context using files like PRODUCT.md and .github/copilot-instructions.md.
- Part 2 details the creation of implementation plans with templates and using specialized agents for TDD.
- Part 3 explores best practices, anti-patterns, and how to scale context engineering for larger teams.

The posts follow the repository's content schema and have been validated with a full project build. Research artifacts were cleaned up prior to submission.

Fixes #7

---
*PR created automatically by Jules for task [7983624452874023586](https://jules.google.com/task/7983624452874023586) started by @viniciuscsouza*