### PR TITLE
Add TurboQuant Blog Post

### DIFF
--- a/src/data/blog/turboquant-redefinindo-a-eficiencia-de-ia-com-compressao-extrema.md
+++ b/src/data/blog/turboquant-redefinindo-a-eficiencia-de-ia-com-compressao-extrema.md
@@ -1,0 +1,64 @@
+---
+author: Vinicius Costa
+pubDatetime: 2026-03-25T19:38:01Z
+title: "TurboQuant: Redefinindo a Eficiência de IA com Compressão Extrema"
+slug: turboquant-redefinindo-a-eficiencia-de-ia-com-compressao-extrema
+featured: false
+draft: false
+tags:
+  - inteligencia-artificial
+  - google
+  - ai
+  - turboquant
+  - llm
+description: "Conheça o TurboQuant, a nova técnica do Google que utiliza PolarQuant e QJL para compressão extrema de LLMs sem perda de precisão."
+---
+
+## O Desafio da Escala em Modelos de Linguagem
+
+À medida que os Modelos de Linguagem de Grande Escala (LLMs) evoluem para lidar com contextos cada vez mais longos, um novo gargalo surge: o consumo de memória do **cache Key-Value (KV)**. Este componente atua como uma "memória de curto prazo" para o modelo, armazenando informações de tokens processados anteriormente para evitar reprocessamento caro.
+
+No entanto, em sequências longas (como as suportadas pelo Gemini ou Llama 3.1), o cache KV pode facilmente exceder a capacidade de memória das GPUs mais potentes. Embora a quantização vetorial seja uma solução clássica, os métodos tradicionais sofrem com o chamado "overhead de memória" — a necessidade de armazenar constantes de quantização (como escala e ponto zero) em alta precisão para cada bloco de dados, o que consome preciosos bits adicionais.
+
+Hoje, exploramos o **TurboQuant**, uma nova família de algoritmos do Google Research que promete redefinir essa eficiência através de compressão extrema com perda zero de acurácia.
+
+## PolarQuant: Uma Nova Perspectiva em Coordenadas Polares
+
+O primeiro pilar do TurboQuant é o **PolarQuant**. Em vez de representar vetores em coordenadas cartesianas padrão (eixos X, Y, Z), o PolarQuant converte os dados para **coordenadas polares** (raio e ângulos).
+
+### Por que isso importa?
+Nas coordenadas tradicionais, os limites dos dados mudam constantemente, exigindo que o modelo calcule e armazene constantes de normalização para cada pequeno bloco de dados. O PolarQuant resolve isso através de um "pré-condicionamento aleatório". Ao rotacionar os vetores aleatoriamente, as coordenadas resultantes seguem uma **distribuição Beta** altamente concentrada e previsível.
+
+Essa previsibilidade permite que o PolarQuant utilize um grid circular fixo, eliminando a necessidade de armazenar constantes de quantização. O resultado é uma compressão de mais de **4.2x** no cache KV mantendo uma qualidade superior aos métodos de estado da arte.
+
+## QJL: O Truque do Bit de Sinal
+
+O segundo componente é o **Quantized Johnson-Lindenstrauss (QJL)**. O QJL utiliza uma transformação matemática para reduzir cada número do vetor a um único **bit de sinal** (+1 ou -1).
+
+O grande diferencial do QJL é o uso de um **estimador assimétrico**. Enquanto os dados armazenados são de baixíssima precisão (1 bit), a consulta (query) permanece em alta precisão. Isso permite calcular o *attention score* de forma não enviesada, garantindo que o modelo foque nas partes corretas do input sem o peso do overhead de memória tradicional.
+
+## TurboQuant: A Sinergia em Dois Estágios
+
+O TurboQuant combina o melhor de ambos os mundos em um processo de dois estágios:
+
+1.  **Compressão de Alta Qualidade (Estágio PolarQuant):** Utiliza a maior parte do orçamento de bits para capturar a estrutura principal do vetor usando coordenadas polares.
+2.  **Eliminação de Erros Residuais (Estágio QJL):** Utiliza apenas 1 bit residual para aplicar o algoritmo QJL sobre o erro que restou do primeiro estágio. Este passo atua como um corretor matemático que elimina vieses, resultando em uma precisão quase perfeita.
+
+## Resultados Experimentais Impressionantes
+
+O TurboQuant foi rigorosamente testado em benchmarks como *LongBench*, *Needle In A Haystack* e *RULER* usando modelos como Gemma e Mistral. Os números falam por si:
+
+-   **Neutralidade de Qualidade:** Alcançou neutralidade absoluta com apenas **3.5 bits** por canal.
+-   **Compressão Extrema:** Redução de pelo menos **6x** no tamanho da memória do cache KV com impacto negligenciável na performance downstream.
+-   **Aceleração de Hardware:** Em GPUs NVIDIA H100, o TurboQuant de 4 bits proporcionou um aumento de performance de até **8x** no cálculo de logits de atenção em comparação com implementações não quantizadas de 32 bits.
+-   **Busca Vetorial:** Em tarefas de busca de vizinhos mais próximos (Nearest Neighbor Search), o método superou técnicas consolidadas como Product Quantization (PQ), reduzindo o tempo de indexação a virtualmente zero devido à sua natureza *data-oblivious*.
+
+## O Futuro da IA Escalável
+
+Mais do que uma solução de engenharia, o TurboQuant oferece uma base teórica sólida que opera perto dos limites inferiores de distorção. À medida que a pesquisa em IA avança para modelos que entendem bilhões de tokens ou motores de busca semântica em escala global, técnicas de quantização online como o TurboQuant serão fundamentais para tornar esses sistemas economicamente viáveis e extremamente rápidos.
+
+---
+
+## 📎 Fonte Original
+
+> Este post foi baseado no artigo original: [TurboQuant: Redefining AI efficiency with extreme compression](https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/)


### PR DESCRIPTION
This PR adds a new technical blog post about Google's TurboQuant algorithm. The post explains the memory bottleneck in KV caches and how TurboQuant addresses it using PolarQuant and QJL techniques. The content is written in PT-BR as per the instructions in GEMINI.md.

Fixes #9

---
*PR created automatically by Jules for task [8605259461105040036](https://jules.google.com/task/8605259461105040036) started by @viniciuscsouza*